### PR TITLE
Configure Supabase env vars for Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Projeto Rumo
+
+Este repositório contém um exemplo de integração com o Supabase e foi configurado para ser implantado na Vercel ou executado localmente.
+
+## Variáveis de ambiente
+
+Para que a aplicação funcione é necessário definir as credenciais do Supabase. Os nomes das variáveis mudam de acordo com o ambiente:
+
+- **Local**: utilize `REACT_APP_SUPABASE_URL` e `REACT_APP_SUPABASE_ANON_KEY`.
+- **Vercel**: utilize `NEXT_PUBLIC_SUPABASE_URL` e `NEXT_PUBLIC_SUPABASE_ANON_KEY`.
+
+As variáveis de ambiente podem ser definidas em um arquivo `.env.local` (para desenvolvimento) ou nas configurações do projeto na Vercel.
+
+## Desenvolvimento local
+
+```bash
+npm install
+npm start
+```
+
+## Deploy na Vercel
+
+O arquivo `vercel.json` está configurado para build estático da pasta `react-supabase-auth-template`. Basta importar o repositório na Vercel e definir as variáveis listadas acima.

--- a/react-supabase-auth-template/src/lib/supabaseClient.js
+++ b/react-supabase-auth-template/src/lib/supabaseClient.js
@@ -1,14 +1,21 @@
 import { createClient } from '@supabase/supabase-js';
 
-if (!process.env.REACT_APP_SUPABASE_URL) {
-  throw new Error('REACT_APP_SUPABASE_URL não está definida');
+const supabaseUrl =
+  process.env.REACT_APP_SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey =
+  process.env.REACT_APP_SUPABASE_ANON_KEY ||
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl) {
+  throw new Error(
+    'Supabase URL is not defined. Set REACT_APP_SUPABASE_URL locally or NEXT_PUBLIC_SUPABASE_URL on Vercel.'
+  );
 }
 
-if (!process.env.REACT_APP_SUPABASE_ANON_KEY) {
-  throw new Error('REACT_APP_SUPABASE_ANON_KEY não está definida');
+if (!supabaseAnonKey) {
+  throw new Error(
+    'Supabase Anon Key is not defined. Set REACT_APP_SUPABASE_ANON_KEY locally or NEXT_PUBLIC_SUPABASE_ANON_KEY on Vercel.'
+  );
 }
 
-const supabaseUrl = process.env.REACT_APP_SUPABASE_URL;
-const supabaseAnonKey = process.env.REACT_APP_SUPABASE_ANON_KEY;
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey); 
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- add README describing local vs Vercel environment configuration
- support both REACT_APP_* and NEXT_PUBLIC_* env vars for Supabase

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851c5981f1c832cb74a274a06db9231