### PR TITLE
Fix Vercel build output path

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "src": "react-supabase-auth-template/package.json",
       "use": "@vercel/static-build",
       "config": {
-        "distDir": "react-supabase-auth-template/build"
+        "distDir": "build"
       }
     }
   ],


### PR DESCRIPTION
## Summary
- adjust `distDir` so Vercel finds the CRA build output

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851cbda67b0832c84d91eed5856b37c