### PR TITLE
Refactor theme usage

### DIFF
--- a/react-supabase-auth-template/src/components/DashboardTable.jsx
+++ b/react-supabase-auth-template/src/components/DashboardTable.jsx
@@ -43,7 +43,7 @@ const newRowInitialState = {
 
 const StyledTableCell = styled(TableCell)(({ theme }) => ({
   '&.MuiTableCell-head': {
-    backgroundColor: '#003865',
+    backgroundColor: theme.palette.primary.main,
     color: theme.palette.common.white,
     fontWeight: 'bold',
   },
@@ -51,7 +51,7 @@ const StyledTableCell = styled(TableCell)(({ theme }) => ({
     position: 'sticky',
     left: 0,
     zIndex: 999,
-    backgroundColor: '#003865',
+    backgroundColor: theme.palette.primary.main,
     color: theme.palette.common.white,
   },
   '&.MuiTableCell-body': {
@@ -312,8 +312,8 @@ function DashboardTable({ tableName }) {
               {monthKeys.map((month) => (
                 <StyledTableCell key={month} sx={{ textAlign: 'center', fontSize: '15px', minWidth: '152.5px' }}>{month}</StyledTableCell>
               ))}
-              <StyledTableCell sx={{ backgroundColor: '#003865', color: '#fff', textAlign: 'center', fontSize: '15px', minWidth: '152.5px' }}>Total Anual</StyledTableCell>
-              <StyledTableCell sx={{ backgroundColor: '#1565a3', color: '#fff', textAlign: 'center', fontSize: '15px', minWidth: '152.5px' }}>Média Anual</StyledTableCell>
+              <StyledTableCell sx={{ backgroundColor: theme.palette.primary.main, color: theme.palette.common.white, textAlign: 'center', fontSize: '15px', minWidth: '152.5px' }}>Total Anual</StyledTableCell>
+              <StyledTableCell sx={{ backgroundColor: theme.palette.secondary.main, color: theme.palette.common.white, textAlign: 'center', fontSize: '15px', minWidth: '152.5px' }}>Média Anual</StyledTableCell>
               {Array.from({ length: 13 }).map((_, index) => (
                 <StyledInvisibleTableCell key={`invisible-head-${index}`}></StyledInvisibleTableCell>
               ))}
@@ -346,20 +346,20 @@ function DashboardTable({ tableName }) {
                     )}
                   </StyledTableCell>
                 ))}
-                <StyledTableCell sx={{ backgroundColor: '#003865', color: '#fff', textAlign: 'center', fontWeight: 'bold', minWidth: '152.5px' }}>{formatNumberForDisplay(row.Total_Anual)}</StyledTableCell>
-                <StyledTableCell sx={{ textAlign: 'center', fontWeight: 'bold', minWidth: '152.5px', backgroundColor: '#1565a3', color: '#fff' }}>{formatNumberForDisplay(row.Media_Anual)}</StyledTableCell>
+                <StyledTableCell sx={{ backgroundColor: theme.palette.primary.main, color: theme.palette.common.white, textAlign: 'center', fontWeight: 'bold', minWidth: '152.5px' }}>{formatNumberForDisplay(row.Total_Anual)}</StyledTableCell>
+                <StyledTableCell sx={{ textAlign: 'center', fontWeight: 'bold', minWidth: '152.5px', backgroundColor: theme.palette.secondary.main, color: theme.palette.common.white }}>{formatNumberForDisplay(row.Media_Anual)}</StyledTableCell>
                 {Array.from({ length: 13 }).map((_, index) => (
                   <StyledInvisibleTableCell key={`invisible-body-${row.id}-${index}`}></StyledInvisibleTableCell>
                 ))}
               </StyledTableRow>
             ))}
             <StyledTableRow>
-              <StyledTableCell className="MuiTableCell-sticky" sx={{ backgroundColor: '#003865', color: '#fff', fontSize: '15px', fontWeight: 'bold' }}>Total</StyledTableCell>
+              <StyledTableCell className="MuiTableCell-sticky" sx={{ backgroundColor: theme.palette.primary.main, color: theme.palette.common.white, fontSize: '15px', fontWeight: 'bold' }}>Total</StyledTableCell>
               {monthKeys.map((month) => (
-                <StyledTableCell key={month} sx={{ backgroundColor: '#003865', color: '#fff', textAlign: 'center', fontSize: '15px', fontWeight: 'bold', minWidth: '152.5px' }}>{formatNumberForDisplay(columnTotals[month])}</StyledTableCell>
+                <StyledTableCell key={month} sx={{ backgroundColor: theme.palette.primary.main, color: theme.palette.common.white, textAlign: 'center', fontSize: '15px', fontWeight: 'bold', minWidth: '152.5px' }}>{formatNumberForDisplay(columnTotals[month])}</StyledTableCell>
               ))}
-              <StyledTableCell sx={{ backgroundColor: '#003865', color: '#fff', textAlign: 'center', fontSize: '15px', fontWeight: 'bold', minWidth: '152.5px' }}>{formatNumberForDisplay(columnTotals.Total_Anual)}</StyledTableCell>
-              <StyledTableCell sx={{ backgroundColor: '#1565a3', color: '#fff', textAlign: 'center', fontSize: '15px', fontWeight: 'bold', minWidth: '152.5px' }}>{formatNumberForDisplay(columnTotals.Media_Anual)}</StyledTableCell>
+              <StyledTableCell sx={{ backgroundColor: theme.palette.primary.main, color: theme.palette.common.white, textAlign: 'center', fontSize: '15px', fontWeight: 'bold', minWidth: '152.5px' }}>{formatNumberForDisplay(columnTotals.Total_Anual)}</StyledTableCell>
+              <StyledTableCell sx={{ backgroundColor: theme.palette.secondary.main, color: theme.palette.common.white, textAlign: 'center', fontSize: '15px', fontWeight: 'bold', minWidth: '152.5px' }}>{formatNumberForDisplay(columnTotals.Media_Anual)}</StyledTableCell>
               {Array.from({ length: 13 }).map((_, index) => (
                 <StyledInvisibleTableCell key={`invisible-total-${index}`}></StyledInvisibleTableCell>
               ))}
@@ -367,8 +367,8 @@ function DashboardTable({ tableName }) {
           </TableBody>
         </Table>
       </TableContainer>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2, backgroundColor: '#fff', padding: '16px 0 0 0' }}>
-        <IconButton sx={{ color: '#003865' }} onClick={() => {
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2, backgroundColor: theme.palette.common.white, padding: '16px 0 0 0' }}>
+        <IconButton sx={{ color: theme.palette.primary.main }} onClick={() => {
           if (tableContainerRef.current) {
             const firstCell = tableContainerRef.current.querySelector('th:not(.MuiTableCell-sticky)');
             if (firstCell) {
@@ -379,7 +379,7 @@ function DashboardTable({ tableName }) {
         }}>
           <ArrowBackIos />
         </IconButton>
-        <IconButton sx={{ color: '#003865' }} onClick={() => {
+        <IconButton sx={{ color: theme.palette.primary.main }} onClick={() => {
           if (tableContainerRef.current) {
             const firstCell = tableContainerRef.current.querySelector('th:not(.MuiTableCell-sticky)');
             if (firstCell) {

--- a/react-supabase-auth-template/src/components/TabbedAdminDashboard.jsx
+++ b/react-supabase-auth-template/src/components/TabbedAdminDashboard.jsx
@@ -31,7 +31,7 @@ const StyledTab = styled(Tab)(({ theme }) => ({
   marginRight: theme.spacing(1),
   opacity: 1,
   '&.Mui-selected': {
-    color: '#003865 !important',
+    color: theme.palette.primary.main,
     backgroundColor: theme.palette.background.paper,
     borderBottomColor: theme.palette.background.paper,
     fontWeight: theme.typography.fontWeightBold,

--- a/react-supabase-auth-template/src/components/TabbedAdminDashboard.jsx
+++ b/react-supabase-auth-template/src/components/TabbedAdminDashboard.jsx
@@ -1,12 +1,12 @@
 // src/components/TabbedAdminDashboard.jsx
 import React, { useState, useMemo } from 'react';
-import { 
-  Box, 
-  Tabs, 
-  Tab, 
-  AppBar, 
-  Toolbar, 
-  Typography, 
+import {
+  Box,
+  Tabs,
+  Tab,
+  AppBar,
+  Toolbar,
+  Typography,
   Container,
   Paper,
   useTheme
@@ -40,6 +40,10 @@ const StyledTab = styled(Tab)(({ theme }) => ({
   border: `1px solid ${theme.palette.divider}`,
   borderBottom: 'none',
 }));
+
+const Logo = styled('img')({
+  height: 140,
+});
 
 const TabbedAdminDashboard = () => {
   const [activeTab, setActiveTab] = useState('ADMINISTRATIVO');
@@ -92,7 +96,7 @@ const TabbedAdminDashboard = () => {
           minHeight: '100px',
           padding: '0 16px',
         }}>
-          <img src="/logo-usifix.png" alt="Logo Usifix" style={{ height: '140px' }} />
+          <Logo src="/logo-usifix.png" alt="Logo Usifix" />
           <Box sx={{ flexGrow: 1, display: 'flex', justifyContent: 'center' }}>
             <StyledTabs
               value={activeTab}

--- a/react-supabase-auth-template/src/index.js
+++ b/react-supabase-auth-template/src/index.js
@@ -1,35 +1,9 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/material/styles';
+import theme from './theme.js';
 import CssBaseline from '@mui/material/CssBaseline';
 import TabbedAdminDashboard from './components/TabbedAdminDashboard.jsx';
-
-const theme = createTheme({
-  palette: {
-    primary: {
-      main: '#1976d2',
-    },
-    secondary: {
-      main: '#dc004e',
-    },
-    background: {
-      default: '#f5f5f5',
-      paper: '#f5f5f5',
-    },
-  },
-  typography: {
-    fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
-  },
-  components: {
-    MuiAppBar: {
-      styleOverrides: {
-        root: {
-          boxShadow: 'none',
-        },
-      },
-    },
-  },
-});
 
 const container = document.getElementById('root');
 if (!container) throw new Error('Failed to find the root element');

--- a/react-supabase-auth-template/src/theme.js
+++ b/react-supabase-auth-template/src/theme.js
@@ -1,0 +1,30 @@
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#003865',
+    },
+    secondary: {
+      main: '#1565a3',
+    },
+    background: {
+      default: '#f5f5f5',
+      paper: '#f5f5f5',
+    },
+  },
+  typography: {
+    fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+  },
+  components: {
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          boxShadow: 'none',
+        },
+      },
+    },
+  },
+});
+
+export default theme;

--- a/src/index.js
+++ b/src/index.js
@@ -1,34 +1,10 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/material/styles';
+import theme from '../react-supabase-auth-template/src/theme.js';
 import CssBaseline from '@mui/material/CssBaseline';
 import TabbedAdminDashboard from './components/TabbedAdminDashboard.jsx';
 
-const theme = createTheme({
-  palette: {
-    primary: {
-      main: '#003865',
-    },
-    secondary: {
-      main: '#dc004e',
-    },
-    background: {
-      default: '#f5f5f5',
-    },
-  },
-  typography: {
-    fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
-  },
-  components: {
-    MuiAppBar: {
-      styleOverrides: {
-        root: {
-          boxShadow: 'none',
-        },
-      },
-    },
-  },
-});
 
 const container = document.getElementById('root');
 if (!container) throw new Error('Failed to find the root element');


### PR DESCRIPTION
## Summary
- centralize MUI theme in `theme.js`
- use theme values in `DashboardTable` and `TabbedAdminDashboard`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851cc56c7b8832cb3ede9cc843af54a