### PR TITLE
Adjust root package for vercel compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,11 @@
 {
+  "name": "projeto-rumo-root",
+  "private": true,
+  "scripts": {
+    "postinstall": "npm install --prefix react-supabase-auth-template",
+    "start": "npm start --prefix react-supabase-auth-template",
+    "build": "npm run build --prefix react-supabase-auth-template"
+  },
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",


### PR DESCRIPTION
## Summary
- add scripts to root `package.json` so npm commands work at the repo root

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851ceadfa2c832c98c9b76c830be4a2