### PR TITLE
Fix supabaseClient path in DashboardTable

### DIFF
--- a/src/DashboardTable.jsx
+++ b/src/DashboardTable.jsx
@@ -1,6 +1,6 @@
 // src/components/DashboardTable.jsx
 import React, { useEffect, useState, useMemo, useRef } from 'react';
-import { supabase } from '../lib/supabaseClient.js';
+import { supabase } from './lib/supabaseClient.js';
 import {
   Box,
   Paper,


### PR DESCRIPTION
## Summary
- fix incorrect path for supabaseClient import in DashboardTable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851f09822b8832c80d34aa954d6b3d7